### PR TITLE
Fix so CLI bucket-prefix option is now respected

### DIFF
--- a/classes/provision.php
+++ b/classes/provision.php
@@ -97,7 +97,7 @@ class provision {
         $this->secret = $secret;
         $this->region = $region;
 
-        if ($this->bucketprefix == '') {
+        if ($bucketprefix == '') {
             $this->bucketprefix = md5($CFG->siteidentifier);
         } else {
             $this->bucketprefix = $bucketprefix;

--- a/tests/provision_test.php
+++ b/tests/provision_test.php
@@ -110,22 +110,22 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
             return new S3Exception('Mock exception', $cmd, array('code' => 403));
         });
 
-            $keyid = 'AAAAAAAAAAAA';
-            $secret = 'aaaaaaaaaaaaaaaaaa';
-            $region = 'ap-southeast-2';
-            $bucketprefix = '';
+        $keyid = 'AAAAAAAAAAAA';
+        $secret = 'aaaaaaaaaaaaaaaaaa';
+        $region = 'ap-southeast-2';
+        $bucketprefix = '';
 
-            $bucketname = 'foobar';
+        $bucketname = 'foobar';
 
-            $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
-            $provisioner->create_s3_client($mock);
+        $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
+        $provisioner->create_s3_client($mock);
 
-            // Reflection magic as we are directly testing a private method.
-            $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'check_bucket_exists');
-            $method->setAccessible(true); // Allow accessing of private method.
-            $result = $method->invoke($provisioner, $bucketname);
+        // Reflection magic as we are directly testing a private method.
+        $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'check_bucket_exists');
+        $method->setAccessible(true); // Allow accessing of private method.
+        $result = $method->invoke($provisioner, $bucketname);
 
-            $this->assertTrue($result);
+        $this->assertTrue($result);
     }
 
     /**
@@ -147,24 +147,24 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
             ));
         });
 
-            $keyid = 'AAAAAAAAAAAA';
-            $secret = 'aaaaaaaaaaaaaaaaaa';
-            $region = 'ap-southeast-2';
-            $bucketprefix = '';
+        $keyid = 'AAAAAAAAAAAA';
+        $secret = 'aaaaaaaaaaaaaaaaaa';
+        $region = 'ap-southeast-2';
+        $bucketprefix = '';
 
-            $bucketname = 'foobar.bah.joo.bar';
+        $bucketname = 'foobar.bah.joo.bar';
 
-            $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
-            $provisioner->create_s3_client($mock);
+        $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
+        $provisioner->create_s3_client($mock);
 
-            // Reflection magic as we are directly testing a private method.
-            $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'create_s3_bucket');
-            $method->setAccessible(true); // Allow accessing of private method.
-            $result = $method->invoke($provisioner, $bucketname);
+        // Reflection magic as we are directly testing a private method.
+        $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'create_s3_bucket');
+        $method->setAccessible(true); // Allow accessing of private method.
+        $result = $method->invoke($provisioner, $bucketname);
 
-            $this->assertFalse($result->status);
-            $this->assertEquals($response['code'], $result->code);
-            $this->assertEquals($response['message'], $result->message);
+        $this->assertFalse($result->status);
+        $this->assertEquals($response['code'], $result->code);
+        $this->assertEquals($response['message'], $result->message);
     }
 
     /**
@@ -176,24 +176,24 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
         $mock = new MockHandler();
         $mock->append(new Result(array('Location' => 'http://foobar.bah.joo.bar.s3.amazonaws.com/')));
 
-            $keyid = 'AAAAAAAAAAAA';
-            $secret = 'aaaaaaaaaaaaaaaaaa';
-            $region = 'ap-southeast-2';
-            $bucketprefix = '';
+        $keyid = 'AAAAAAAAAAAA';
+        $secret = 'aaaaaaaaaaaaaaaaaa';
+        $region = 'ap-southeast-2';
+        $bucketprefix = '';
 
-            $bucketname = 'foobar.bah.joo.bar';
+        $bucketname = 'foobar.bah.joo.bar';
 
-            $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
-            $provisioner->create_s3_client($mock);
+        $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
+        $provisioner->create_s3_client($mock);
 
-            // Reflection magic as we are directly testing a private method.
-            $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'create_s3_bucket');
-            $method->setAccessible(true); // Allow accessing of private method.
-            $result = $method->invoke($provisioner, $bucketname);
+        // Reflection magic as we are directly testing a private method.
+        $method = new ReflectionMethod('\fileconverter_librelambda\provision', 'create_s3_bucket');
+        $method->setAccessible(true); // Allow accessing of private method.
+        $result = $method->invoke($provisioner, $bucketname);
 
-            $this->assertTrue($result->status);
-            $this->assertEquals(0, $result->code);
-            $this->assertEquals('http://foobar.bah.joo.bar.s3.amazonaws.com/', $result->message);
+        $this->assertTrue($result->status);
+        $this->assertEquals(0, $result->code);
+        $this->assertEquals('http://foobar.bah.joo.bar.s3.amazonaws.com/', $result->message);
     }
 
     /**

--- a/tests/provision_test.php
+++ b/tests/provision_test.php
@@ -196,5 +196,24 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
             $this->assertEquals('http://foobar.bah.joo.bar.s3.amazonaws.com/', $result->message);
     }
 
+    /**
+     * Test that bucketprefix is set as expected.
+     */
+    public function test_bucketprefix_is_set_correctly() {
+        global $CFG;
+
+        $keyid = 'AAAAAAAAAAAA';
+        $secret = 'aaaaaaaaaaaaaaaaaa';
+        $region = 'ap-southeast-2';
+
+        $bucketprefix = '';
+        $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
+        $this->assertEquals(md5($CFG->siteidentifier), $provisioner->get_bucket_prefix());
+
+        $bucketprefix = 'test_prefix';
+        $provisioner = new \fileconverter_librelambda\provision($keyid, $secret, $region, $bucketprefix);
+        $this->assertEquals('test_prefix', $provisioner->get_bucket_prefix());
+    }
+
 
 }


### PR DESCRIPTION
Prior to this site identifier was always used. Closes #13 