### PR TITLE
fix failing test unit after aws sdk update to 3.280.1

### DIFF
--- a/tests/converter_test.php
+++ b/tests/converter_test.php
@@ -189,6 +189,7 @@ class fileconverter_librelambda_converter_testcase extends advanced_testcase {
     public function test_start_document_conversion() {
         global $CFG;
         $this->resetAfterTest();
+        set_config('s3_input_bucket', 'bucket1', 'fileconverter_librelambda');
 
         $course = $this->getDataGenerator()->create_course();
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_assign');
@@ -278,6 +279,8 @@ class fileconverter_librelambda_converter_testcase extends advanced_testcase {
     public function test_poll_document_conversion_already_progress() {
         global $CFG;
         $this->resetAfterTest();
+        set_config('s3_input_bucket', 'bucket1', 'fileconverter_librelambda');
+        set_config('s3_output_bucket', 'bucket2', 'fileconverter_librelambda');
 
         $course = $this->getDataGenerator()->create_course();
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_assign');
@@ -326,6 +329,8 @@ class fileconverter_librelambda_converter_testcase extends advanced_testcase {
     public function test_execute_conversion_task_progress() {
         global $CFG;
         $this->resetAfterTest();
+        set_config('s3_input_bucket', 'bucket1', 'fileconverter_librelambda');
+        set_config('s3_output_bucket', 'bucket2', 'fileconverter_librelambda');
 
         $course = $this->getDataGenerator()->create_course();
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_assign');


### PR DESCRIPTION
Update to 3.280.1 [SDK](https://github.com/aws/aws-sdk-php) 

Fixes issue 2-4 when running unit tests:

```
There were 4 failures:

1) dml_test::test_unique_index_collation_trouble
Unique index is accent insensitive, this may cause problems for non-ascii languages. This is usually caused by accent insensitive default collation.

/siteroot/lib/dml/tests/dml_test.php:3999
/siteroot/lib/phpunit/classes/database_driver_testcase.php:143
/siteroot/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "dml_test" lib/dml/tests/dml_test.php

2) fileconverter_librelambda_converter_testcase::test_start_document_conversion
Failed asserting that -1 matches expected 1.

/siteroot/files/converter/librelambda/tests/converter_test.php:225
/siteroot/lib/phpunit/classes/advanced_testcase.php:80
/siteroot/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "fileconverter_librelambda_converter_testcase" files/converter/librelambda/tests/converter_test.php

3) fileconverter_librelambda_converter_testcase::test_poll_document_conversion_already_progress
Failed asserting that -1 matches expected 1.

/siteroot/files/converter/librelambda/tests/converter_test.php:319
/siteroot/lib/phpunit/classes/advanced_testcase.php:80
/siteroot/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "fileconverter_librelambda_converter_testcase" files/converter/librelambda/tests/converter_test.php

4) fileconverter_librelambda_converter_testcase::test_execute_conversion_task_progress
Failed asserting that -1 matches expected 1.

/siteroot/files/converter/librelambda/tests/converter_test.php:372
/siteroot/lib/phpunit/classes/advanced_testcase.php:80
/siteroot/vendor/phpunit/phpunit/phpunit:60

To re-run:
 vendor/bin/phpunit "fileconverter_librelambda_converter_testcase" files/converter/librelambda/tests/converter_test.php
```