### PR TITLE
Add extra extenstions

### DIFF
--- a/classes/converter.php
+++ b/classes/converter.php
@@ -43,17 +43,21 @@ class converter implements \core_files\converter_interface {
     private static $imports = [
         'doc' => 'application/msword',
         'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'dotx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
         'rtf' => 'application/rtf',
         'xls' => 'application/vnd.ms-excel',
         'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'pot' => 'application/vnd.ms-powerpoint',
         'ppt' => 'application/vnd.ms-powerpoint',
         'pptx' => 'application/vnd.ms-powerpoint',
         'html' => 'text/html',
         'odt' => 'application/vnd.oasis.opendocument.text',
         'ods' => 'application/vnd.oasis.opendocument.spreadsheet',
         'png' => 'image/png',
+        'jpeg' => 'image/jpeg',
         'jpg' => 'image/jpeg',
         'txt' => 'text/plain',
+        'csv' => 'text/csv',
         'gif' => 'image/gif',
     ];
 

--- a/tests/converter_test.php
+++ b/tests/converter_test.php
@@ -549,25 +549,31 @@ class converter_test extends \advanced_testcase {
 
     /**
      * Data provider for test_supports
-     * Supported formats: 'doc', 'docx', 'rtf', 'xls', 'xlsx', 'ppt', 'pptx', 'html', 'odt',
-     * 'ods', 'txt', 'png', 'jpg', 'gif', 'pdf'
      *
      * @return array
      */
     public function supports_provider() {
         return [
             ['doc', true], ['DOC', true],
+            ['docm', false], ['DOCM', false],
             ['docx', true], ['DOCX', true],
+            ['dotx', true], ['DOTX', true],
             ['rtf', true], ['RTF', true],
             ['xls', true], ['XLS', true],
+            ['xlsm', false], ['XLSM', false],
             ['xlsx', true], ['XLSX', true],
+            ['xltm', false], ['XLTM', false],
+            ['pot', true], ['POT', true],
             ['ppt', true], ['PPT', true],
+            ['pptm', false], ['PPTM', false],
             ['pptx', true], ['PPTX', true],
             ['html', true], ['HTML', true],
             ['odt', true], ['ODT', true],
             ['ods', true], ['ODS', true],
             ['txt', true], ['TXT', true],
+            ['csv', true], ['CSV', true],
             ['png', true], ['PNG', true],
+            ['jpeg', true], ['JPEG', true],
             ['jpg', true], ['JPG', true],
             ['gif', true], ['GIF', true],
             ['pdf', false], ['PDF', false],


### PR DESCRIPTION
Add extension variants for MS word, excel, powerpoint, and jpg (plus csv)

I have run the following command

`./instdir/program/soffice.bin --headless --invisible --nodefault --nofirststartwizard \ --nolockcheck --nologo --norestore --convert-to pdf --outdir $(pwd)  afile.extension`

The conversion completed successfully for those extensions.
